### PR TITLE
withdraw withdrawn rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.6
+- withdraw already-withdrawn rewards (as a result of re/undelegation) in the withdraw staking reward execute endpoint
+
 # 0.1.5
 - Add validations for timestamp in tranche: earliest must be later than current block time and latest must be within 100 years
 - Fix validation that enforces equal timestamp and amount size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gringotts"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [lib]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -346,10 +346,12 @@ fn execute_initiate_withdraw_reward(
     authorize_op(deps.storage, info.sender)?;
     let mut response = Response::new();
     let mut total = calculate_withdrawn_rewards(deps.as_ref(), env.clone())?;
-    response = response.add_message(BankMsg::Send {
-        to_address: STAKING_REWARD_ADDRESS.load(deps.storage)?.to_string(),
-        amount: coins(total, DENOM.load(deps.storage)?),
-    });
+    if total > 0 {
+        response = response.add_message(BankMsg::Send {
+            to_address: STAKING_REWARD_ADDRESS.load(deps.storage)?.to_string(),
+            amount: coins(total, DENOM.load(deps.storage)?),
+        });
+    }
     for validator in get_all_delegated_validators(deps.as_ref(), env.clone())? {
         let withdrawable_amount =
             get_delegation_rewards(deps.as_ref(), env.clone(), validator.clone())?;


### PR DESCRIPTION
## Describe your changes and provide context
rewards may be automatically withdrawn to contract's bank balance during redelegation/undelegation/delegating more to the same validator. The amount of such withdrawn rewards, assuming no external deposit to the contract is present, can be calculated as: bank balance - (total - withdrawn principal - staked - unbonding).
Note that because CW currently doesn't support querying unbonding amount, we will ignore unbonding amount in the calculationg for now. This would make under-withdraw possible but still impossible to over-withdraw (which is bad).
To avoid under-withdraw, the operator can wait till there is no unbonding amount for the contract when executing
rewards withdrawal.


## Testing performed to validate your change
unit test & local sei test