### PR TITLE
Add msgs for updating unlocked distribution address and staking rewards distribution address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.wasm
 hash.txt
 contracts.txt
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+#0.1.7
+- Add msgs for updating unlocked distribution address and staking rewards distribution address
 # 0.1.6
 - withdraw already-withdrawn rewards (as a result of re/undelegation) in the withdraw staking reward execute endpoint
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gringotts"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [lib]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -44,6 +44,12 @@ pub enum ExecuteMsg {
         admin: Addr,
         remove: bool,
     },
+    ProposeUpdateUnlockedDistributionAddress {
+        unlocked_distribution_address: Addr,
+    },
+    ProposeUpdateStakingRewardDistributionAddress {
+        staking_reward_distribution_address: Addr,
+    },
     ProposeGovVote {
         gov_proposal_id: u64,
         gov_vote: VoteOption,
@@ -57,6 +63,12 @@ pub enum ExecuteMsg {
     InternalUpdateAdmin {
         admin: Addr,
         remove: bool,
+    },
+    InternalUpdateUnlockedDistributionAddress {
+        unlocked_distribution_address: Addr,
+    },
+    InternalUpdateStakingRewardDistributionAddress {
+        staking_reward_distribution_address: Addr,
     },
     InternalWithdrawLocked {
         dst: Addr,


### PR DESCRIPTION
## Describe your changes and provide context
Add messages to allow for  updating unlocked distribution address and staking rewards distribution address.  

## Testing performed to validate your change
Unit tests, and also verified on autobake cluster