### PR TITLE
Check withdrawable amount is zero before transferring

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup
-      run: rustup update && rustup install 1.65.0 && rustup default 1.65.0
+      run: rustup update && rustup install 1.91.1 && rustup default 1.91.1
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gringotts"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [lib]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -411,9 +411,11 @@ fn execute_initiate_withdraw_reward(
     for validator in get_all_delegated_validators(deps.as_ref(), env.clone())? {
         let withdrawable_amount =
             get_delegation_rewards(deps.as_ref(), env.clone(), validator.clone())?;
-        response =
-            withdraw_delegation_rewards(deps.as_ref(), response, validator, withdrawable_amount)?;
-        total += withdrawable_amount;
+        if withdrawable_amount > 0 {
+            response =
+                withdraw_delegation_rewards(deps.as_ref(), response, validator, withdrawable_amount)?;
+            total += withdrawable_amount;
+        }
     }
     WITHDRAWN_STAKING_REWARDS.update(deps.storage, |old| -> Result<u128, StdError> {
         Ok(old + total)


### PR DESCRIPTION
## Describe your changes and provide context
Withdrawing rewards involves dispatching a bank transfer event which will error out if the amount is zero, so we need to check whether the reward amount is zero before withdrawing

## Testing performed to validate your change
unit test